### PR TITLE
Add libgit2 dependency for desktop client

### DIFF
--- a/opencloud/opencloud-desktop/opencloud-desktop.py
+++ b/opencloud/opencloud-desktop/opencloud-desktop.py
@@ -35,6 +35,7 @@ class subinfo(info.infoclass):
         self.runtimeDependencies["opencloud/libre-graph-api-cpp-qt-client"] = None
         self.runtimeDependencies["libs/zlib"] = None
         self.runtimeDependencies["libs/sqlite"] = None
+        self.runtimeDependencies["libs/libgit2"] = None
         if CraftCore.compiler.isWindows:
             self.runtimeDependencies["dev-utils/snoretoast"] = None
 


### PR DESCRIPTION
## Context

Follow-up for https://github.com/orgs/opencloud-eu/discussions/2891.

The desktop client change adds libgit2-based text conflict automerge: https://github.com/opencloud-eu/desktop/pull/934. This PR makes the Craft blueprint resolve and package libgit2 for `opencloud/opencloud-desktop`.

## Changes

- Add `libs/libgit2` as a runtime dependency of the OpenCloud Desktop Craft blueprint.

## Verification

- Removed the local `opencloud/opencloud-desktop` Craft build tree and the blueprint `__pycache__` so Craft had to re-evaluate the changed blueprint.
- Rebuilt through Craft with the desktop repo `.craft.ini` and workflow override using `-i --install-deps --compile --install`.
- CMake configure found `LibGit2` from the Craft prefix.
- Craft compile completed successfully (`450/450`), install succeeded, and qmerge succeeded.
- Verified the qmerged `OpenCloudLibSync.dll` depends on `git2.dll` with `dumpbin /dependents`.